### PR TITLE
Bug fix with setting message delimiter and string optimizations

### DIFF
--- a/src/ofxMPEClient.h
+++ b/src/ofxMPEClient.h
@@ -22,7 +22,6 @@
 #include "ofxNetwork.h"
 #include "ofxXmlSettings.h"
 
-
 //--------------------------------------------------------------
 class ofxMPEClient : public ofThread {
 
@@ -81,7 +80,7 @@ class ofxMPEClient : public ofThread {
     bool  isOnScreen(float _x, float _y);
     bool  isOnScreen(float _x, float _y, float _w, float _h);
 
-    void  broadcast(string _msg);
+    void  broadcast(const string &_msg);
     bool  areAllConnected() { return allConnected; }
 
 
@@ -90,6 +89,7 @@ class ofxMPEClient : public ofThread {
 
 	bool verbose;
 	string delimiter;
+	string messageDelimiter;
 	
     void draw(ofEventArgs& e);
     void retryConnectionLoop(ofEventArgs& e);
@@ -107,7 +107,7 @@ class ofxMPEClient : public ofThread {
     void setupViewport();
 
     void read(string _serverInput);
-    void send(string _msg);
+    void send(string &_msg);
 
     void reset();
 
@@ -176,5 +176,4 @@ class ofxMPEClient : public ofThread {
     bool  bEnable3D;
     float fieldOfView;
     float cameraZ;
-
 };

--- a/src/ofxMPEServer.h
+++ b/src/ofxMPEServer.h
@@ -20,7 +20,6 @@
 #include "ofMain.h"
 #include "ofxNetwork.h"
 
-
 typedef struct
 {
 	string name;


### PR DESCRIPTION
Just some updates I've com across while working with MPE in OF. Im not sure the first two items here are 100% needed but the rest are definite improvements. Thanks for the work so far.

verbose off by default
reserve 1k for ourgoing string to prevent allocation slowdown
set the message delimiter in the client to newline to match the servers default (prevents examples from running)
removed some cout loging
converted M_PI to PI to match new OF standard
uncommented framecount incrementor in simulation mode
strings now passed by refrence whenever possible
string concatination via + replaced with += or append in most instnaces
sever continues to send frame updates when a new client connects after all previous clients had disconnected. Kind of edge case but happends a lot when debugging.

PS sorry for the spelling in the commit message. It was late and I don't spell well.
